### PR TITLE
Readline

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -229,6 +229,11 @@ FtpConnection.prototype._onData = function(data) {
     commandArg = '';
   }
 
+  if (commandArg.indexOf('\\r') !== -1 || commandArg.indexOf('\\n')) {
+    self.respond('501', 'Syntax error in parameters or arguments.');
+    return;
+  }
+
   var m = '_command_' + command;
   if (self[m]) {
     if (self.allowedCommands != null && self.allowedCommands[command] !== true) {

--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -7,6 +7,7 @@ var path = require('path');
 var fsModule = require('fs');
 var StatMode = require('stat-mode');
 var dateformat = require('dateformat');
+const readline = require('readline');
 
 var glob = require('./glob');
 var starttls = require('./starttls');
@@ -37,10 +38,15 @@ function FtpConnection(properties) {
   self.socket.setTimeout(0);
   self.socket.setNoDelay();
 
-  self.socket.on('data', self._onData.bind(self));
   self.socket.on('end', endHandler);
   self.socket.on('error', self._onError.bind(self));
   self.socket.on('close', self._onClose.bind(self));
+
+  const rl = readline.createInterface({
+    input: self.socket,
+    crlfDelay: Infinity,
+  });
+  rl.on('line', self._onData.bind(self));
 
   self._writeBanner();
   self._logIf(LOG.INFO, 'Accepted a new client connection');


### PR DESCRIPTION
Detect literal strings `"\r"` or `"\n"` in command arguments. I think a client is mistakenly sending these chars in place of an actual CRLF.