### PR TITLE
Use readline for reading data line by line.

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -7,6 +7,7 @@ var path = require('path');
 var fsModule = require('fs');
 var StatMode = require('stat-mode');
 var dateformat = require('dateformat');
+var readline = require('readline');
 
 var glob = require('./glob');
 var starttls = require('./starttls');
@@ -34,14 +35,15 @@ function FtpConnection(properties) {
     self[key] = properties[key];
   });
 
+  self.readline = null;
   self.socket.setTimeout(0);
   self.socket.setNoDelay();
 
   self.socket.on('end', endHandler);
   self.socket.on('error', self._onError.bind(self));
   self.socket.on('close', self._onClose.bind(self));
-  self.socket.on('data', self._onData.bind(self));
 
+  self._setupOnData(self.socket);
   self._writeBanner();
   self._logIf(LOG.INFO, 'Accepted a new client connection');
 
@@ -51,6 +53,20 @@ function FtpConnection(properties) {
 }
 
 util.inherits(FtpConnection, EventEmitter);
+
+FtpConnection.prototype._setupOnData = function(socket) {
+  self.socket = socket;
+  if (self.readline) {
+    self.readline.close();
+  }
+  self.readline = readline.createInterface({
+    input: socket,
+    crlfDelay: Infinity,
+    historySize: 0,
+    terminal: false,
+  })
+  self.readline.on('line', self._onData.bind(self));
+};
 
 FtpConnection.prototype._onError = function(e) {
   this._logIf(LOG.ERROR, 'Client connection error: ' + util.inspect(e));
@@ -289,10 +305,7 @@ FtpConnection.prototype._command_AUTH = function(commandArg) {
 
       if (secureSocket.authorized || self.server.options.allowUnauthorizedTls) {
         self._logIf(LOG.INFO, 'Secure connection started');
-        self.socket = secureSocket;
-        self.socket.on('data', function(data) {
-          self._onData(data);
-        });
+        self._setupOnData(secureSocket);
         self.secure = true;
         return;
       }


### PR DESCRIPTION
This version uses readline, and it handles the transition to SSL by wrapping the TLS socket with readline.